### PR TITLE
Bind to window instead of datacontext

### DIFF
--- a/WpfApplication1/AddCommand.cs
+++ b/WpfApplication1/AddCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 
 namespace WpfApplication1
@@ -24,7 +25,10 @@ namespace WpfApplication1
 
         public void Execute(object parameter)
         {
-            this.ViewModel.AddMusician(parameter as Musician);                        
+            var win = (FrameworkElement)parameter;
+            var musician = (Musician)win.DataContext;
+            this.ViewModel.AddMusician(musician);
+            win.DataContext = new Musician();
         }
     }
 }

--- a/WpfApplication1/MainWindow.xaml
+++ b/WpfApplication1/MainWindow.xaml
@@ -55,7 +55,7 @@
                  ItemsSource="{Binding}"/>
 
         <Button x:Name="addButton" Grid.Column="3" Grid.Row="1" Margin="10" FontSize="16" Width="70" Content="Add" 
-                Command="{Binding AddCommand, Source={StaticResource vm}}" CommandParameter="{Binding}" Click="addButton_Click"/>
+                Command="{Binding AddCommand, Source={StaticResource vm}}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}}" Click="addButton_Click"/>
 
         <CheckBox 
             x:Name="isActive" Grid.Column="3" Grid.Row="3" 


### PR DESCRIPTION
This way we can replace the DataContext with a new (empty) Musician object instead of staying bound to the one we added to the Musician ObservableCollection