### PR TITLE
Clone the musician and store that, then clear the one that's bound to the text boxes

### DIFF
--- a/WpfApplication1/AddCommand.cs
+++ b/WpfApplication1/AddCommand.cs
@@ -24,7 +24,13 @@ namespace WpfApplication1
 
         public void Execute(object parameter)
         {
-            this.ViewModel.AddMusician(parameter as Musician);                        
+            var editableMusician = (Musician)parameter;
+
+            var clonedMusician = (Musician)editableMusician.Clone();
+
+            editableMusician.Clear();
+
+            this.ViewModel.AddMusician(clonedMusician);
         }
     }
 }

--- a/WpfApplication1/MainWindow.xaml.cs
+++ b/WpfApplication1/MainWindow.xaml.cs
@@ -31,9 +31,9 @@ namespace WpfApplication1
 
         private void addButton_Click(object sender, RoutedEventArgs e)
         {
-            this.textBoxOfFirstName.Clear();
-            this.textBoxOfLastName.Clear();
-            this.textBoxOfFullName.Clear();
+            //this.textBoxOfFirstName.Clear();
+            //this.textBoxOfLastName.Clear();
+            //this.textBoxOfFullName.Clear();
         }
     }
 }

--- a/WpfApplication1/Musician.cs
+++ b/WpfApplication1/Musician.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 
 namespace WpfApplication1
 {
-    public class Musician : INotifyPropertyChanged
+    public class Musician : INotifyPropertyChanged, ICloneable
     {
         private bool isActive;
         private string firstName;
@@ -49,20 +49,27 @@ namespace WpfApplication1
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
+        public object Clone() {
+            return new Musician {
+                FirstName = this.FirstName,
+                LastName = this.LastName,
+                IsActive = this.IsActive
+            };
+        }
+
+        public void Clear() {
+            FirstName = string.Empty;
+            LastName = string.Empty;
+            IsActive = false;
+        }
+
         public void OnPropertyChanged(String propertyName)
         {
-            if(propertyName != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-                
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
         public override string ToString()
         {
             return FullName;
         }
-
-
-
     }
 }


### PR DESCRIPTION
This method doesn't require interacting with any UI elements (Window, buttons, textboxes, etc).

Also fix PropertyChanged event. PropertyChanged with a null `propertyName` is a valid process in WPF, which tells all the listeners of the event that ALL properties on that object have changed.
the `?.` is required so that we don't fire the event if noone is listening (this causes a NullReferenceException)